### PR TITLE
feat: add Mark Reviewed action for completed agent tasks

### DIFF
--- a/mission-control/src/app/page.tsx
+++ b/mission-control/src/app/page.tsx
@@ -126,6 +126,7 @@ export default function CommandCenterPage() {
   const unreadReports = unreadMessages.filter((m) => m.type === "report");
   const recentCompletions = tasks.filter(
     (t) => t.kanban === "done" && t.assignedTo && t.assignedTo !== "me" && t.completedAt &&
+    !t.reviewed &&
     (Date.now() - new Date(t.completedAt).getTime()) < 7 * 24 * 60 * 60 * 1000
   );
   const attentionItems = [

--- a/mission-control/src/components/task-detail-panel.tsx
+++ b/mission-control/src/components/task-detail-panel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 import {
   X, Trash2, ListChecks, Link2, CheckCircle2, Rocket,
-  Send, Clock, MessageSquare, Activity,
+  Send, Clock, MessageSquare, Activity, Eye,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TaskForm, type TaskFormData } from "@/components/task-form";
@@ -28,6 +28,7 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Tip } from "@/components/ui/tip";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { apiFetch } from "@/lib/api-client";
 
 const quadrantLabels: Record<string, { label: string; color: string }> = {
   do: { label: "DO", color: "bg-quadrant-do/20 text-quadrant-do border-quadrant-do/30" },
@@ -121,6 +122,20 @@ export function TaskDetailPanel({ task, projects, goals, allTasks, onUpdate, onD
     [task, agents, onUpdate, onClose]
   );
 
+  const handleMarkReviewed = useCallback(async () => {
+    try {
+      await apiFetch("/api/tasks", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: task.id, reviewed: true }),
+      });
+      toast.success("Marked as reviewed");
+      onClose();
+    } catch {
+      toast.error("Failed to mark reviewed");
+    }
+  }, [task.id, onClose]);
+
   const handleAddComment = useCallback(async () => {
     const trimmed = commentText.trim();
     if (!trimmed) return;
@@ -133,7 +148,7 @@ export function TaskDetailPanel({ task, projects, goals, allTasks, onUpdate, onD
     };
     const existingComments = task.comments ?? [];
     try {
-      await fetch("/api/tasks", {
+      await apiFetch("/api/tasks", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -249,6 +264,20 @@ export function TaskDetailPanel({ task, projects, goals, allTasks, onUpdate, onD
             )}
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            {/* Mark reviewed button — shown for done agent tasks not yet reviewed */}
+            {task.kanban === "done" && task.assignedTo && task.assignedTo !== "me" && !task.reviewed && (
+              <Tip content="Mark as reviewed — removes from Attention Required">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-green-500 hover:bg-green-500/10"
+                  aria-label="Mark as reviewed"
+                  onClick={handleMarkReviewed}
+                >
+                  <Eye className="h-4 w-4" />
+                </Button>
+              </Tip>
+            )}
             {/* Deploy button */}
             <DropdownMenu>
               <Tip content="Deploy to agent">

--- a/mission-control/src/lib/types.ts
+++ b/mission-control/src/lib/types.ts
@@ -181,6 +181,7 @@ export interface Task {
   updatedAt: string;
   completedAt: string | null;
   deletedAt: string | null;
+  reviewed?: boolean;
 }
 
 export interface TasksFile {


### PR DESCRIPTION
## Problem

The Command Center shows an "Attention Required" banner for completed agent tasks that stays visible for 7 days. Users who have already reviewed the work have no way to dismiss it sooner.

## Solution

Adds a **Mark Reviewed** action to the task detail panel.

- New `reviewed?: boolean` field on the `Task` interface
- A green **Eye** button appears in the task detail panel header when a task is `done`, assigned to an agent (not `me`), and hasn't been reviewed yet
- Clicking it PATCHes `reviewed: true` and closes the panel
- The "completed tasks to review" attention item on Command Center is hidden for reviewed tasks

## Changes

- `src/lib/types.ts` — adds `reviewed?: boolean` to `Task`
- `src/components/task-detail-panel.tsx` — adds `handleMarkReviewed` + Eye icon button
- `src/app/page.tsx` — excludes reviewed tasks from `recentCompletions` filter

## Test plan

- [ ] Complete a task assigned to an agent
- [ ] Verify "Attention Required" banner appears on Command Center
- [ ] Open the task → confirm green Eye button is visible in the header
- [ ] Click Eye → panel closes, banner disappears
- [ ] Re-open task → Eye button is gone (already reviewed)
- [ ] Verify tasks assigned to `me` or not in `done` state don't show the Eye button

🤖 Generated with [Claude Code](https://claude.com/claude-code)