### PR TITLE
feat: Bobby TAIS Sentinel — detecção contínua + alertas Telegram

### DIFF
--- a/.github/workflows/bobby-sentinel.yml
+++ b/.github/workflows/bobby-sentinel.yml
@@ -1,0 +1,58 @@
+name: Bobby TAIS Sentinel
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # detect+act a cada 15 min
+    - cron: '0 22 * * *'     # 19h BRT (UTC-3) = 22 UTC → digest diário
+  workflow_dispatch:
+
+jobs:
+  sentinel:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout mission-control
+        uses: actions/checkout@v4
+        with:
+          path: mission-control
+
+      - name: Checkout tais-edge
+        uses: actions/checkout@v4
+        with:
+          repository: terserv/tais-edge
+          token: ${{ secrets.GH_PAT }}
+          path: tais-edge
+        continue-on-error: true  # remote pode não existir ainda
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install anthropic supabase requests
+
+      - name: Run Bobby
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SUPABASE_URL: https://rixnvftlzhfkavbfcipn.supabase.co
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_MONITOR: ${{ secrets.TELEGRAM_CHAT_MONITOR }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          IS_DIGEST: ${{ github.event.schedule == '0 22 * * *' }}
+          TAIS_EDGE_PATH: ${{ github.workspace }}/tais-edge
+        run: python mission-control/agents/bobby/sentinel.py

--- a/agents/bobby/SKILL.md
+++ b/agents/bobby/SKILL.md
@@ -1,0 +1,85 @@
+# Bobby — DevOps + TAIS Sentinel
+
+Bobby monitora a TAIS continuamente, classifica incidentes vindos do
+`tais_incidents` (Supabase project `rixnvftlzhfkavbfcipn`), e aplica fixes
+whitelistados sem intervenção. Casos fora da whitelist, anota diagnóstico
+e alerta Fred via Telegram.
+
+## Origem dos incidents
+
+Cron `tais-sentinel-detect` (a cada 15 min) roda 5 detectores em SQL
+(`detect_bot_message_repeat`, `detect_menu_loop_escalations`,
+`detect_generic_fallbacks`, `detect_stale_conversations`,
+`detect_hallucinations`). Cada match vira linha em `tais_incidents` com
+`status='open'`. Bobby lê essa tabela.
+
+## Whitelist auto-fix (conservadora — começa só com 1 tipo)
+
+| kind | auto-fix? | ação |
+|---|---|---|
+| `generic_fallback` | ✅ sim | Identifica o user_text que disparou; adiciona regex ao `TOPIC_KEYWORD_MAP` em `_shared/handlers.ts` com resposta apropriada; `deno check`; deploy; commit. |
+| `bot_message_repeat` (prefix conhecido) | ❌ não ainda | Apenas alerta. Pode evoluir pra investigar se `TOPIC_KEYWORD_MAP` cobre o termo. |
+| `menu_loop_escalation` | ❌ não | Sintoma, não causa. Alerta. |
+| `stale_conversation` | ❌ não | Alerta. |
+| `hallucination` | ❌ não | Alerta. Caso crítico — review humano obrigatório. |
+
+> Decisão arquitetural: começa com whitelist mínima (só `generic_fallback`),
+> que é o caso mais previsível e de menor blast radius. Expande à medida
+> que confiança aumenta.
+
+## Procedimento por incidente
+
+1. `SELECT * FROM tais_incidents WHERE status='open' ORDER BY severity DESC, last_seen_at DESC LIMIT 20`
+2. Pra cada um da whitelist:
+   - Lê `audit_log` dos últimos 1h da conversa pra identificar o `user_text` que disparou
+   - Aplica patch (str_replace em `_shared/handlers.ts` no repo `~/tais-edge` checkado no runner)
+   - `deno check` — se falhar, aborta e marca incident como `acknowledged` com nota
+   - Deploy via `supabase functions deploy webhook-handler --no-verify-jwt`
+   - Commit em `tais-edge` (push só se remote existir — atualmente NÃO existe)
+   - `UPDATE tais_incidents SET status='auto_fixed', auto_fix_attempted=true,
+     auto_fix_result='{"commit": "...", "version": "..."}'::jsonb, resolved_at=now()`
+3. Pra fora da whitelist:
+   - `UPDATE tais_incidents SET status='acknowledged', notes='<diagnóstico>'`
+   - Telegram alerta Fred (canal `TELEGRAM_CHAT_MONITOR`)
+
+## Digest diário (19h BRT = 22 UTC)
+
+Lista tudo que ele auto-fixou + tudo que ficou pendente nas últimas 24h.
+Manda no Telegram como mensagem agrupada.
+
+## Onde rodar
+
+GitHub Action `.github/workflows/bobby-sentinel.yml`:
+- Schedule a cada 15 min (alinhado com o cron `tais-sentinel-detect`)
+- Schedule extra às 22 UTC pro digest
+- Workflow_dispatch pra trigger manual
+
+## Secrets necessárias (GitHub Settings → Secrets)
+
+| Secret | Origem |
+|---|---|
+| `ANTHROPIC_API_KEY` | Conta Anthropic |
+| `SUPABASE_URL` | `https://rixnvftlzhfkavbfcipn.supabase.co` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase dashboard → Project Settings → API |
+| `SUPABASE_ACCESS_TOKEN` | Supabase dashboard → Account → Access Tokens |
+| `TELEGRAM_BOT_TOKEN` | Já existe no projeto TAIS |
+| `TELEGRAM_CHAT_MONITOR` | Já existe no projeto TAIS |
+| `GH_PAT` | Token com `repo:write` em `terserv/tais-edge` (quando o remote for criado) |
+
+## Como pausar Bobby
+
+- Edit `.github/workflows/bobby-sentinel.yml` → comenta o bloco `schedule:` → push
+- Ou: GitHub UI → Actions → workflow Bobby TAIS Sentinel → "Disable workflow"
+
+## Como adicionar pattern à whitelist
+
+1. Edita `agents/bobby/sentinel.py` → constante `AUTO_FIX_WHITELIST_KINDS`
+2. PR
+3. Após merge, próxima execução agendada já considera o novo tipo
+
+## Evolução planejada
+
+- v1 (atual): só `generic_fallback`, edição manual de `TOPIC_KEYWORD_MAP`
+- v2: `bot_message_repeat` com prefix em fallback → analisa contexto, sugere regex
+- v3: integração com Mika (QA) pra rodar bateria de teste após auto-fix
+- v4: rollback automático se função saúde piorar 1h pós-deploy

--- a/agents/bobby/sentinel.py
+++ b/agents/bobby/sentinel.py
@@ -1,0 +1,178 @@
+"""
+Bobby — TAIS Sentinel runner.
+
+Conservador na v1: apenas LÊ incidents, marca os fora-da-whitelist
+como acknowledged, e alerta Telegram. Auto-fix de `generic_fallback`
+é o ÚNICO tipo whitelistado, mas implementação completa do patch
+(Anthropic tool_use loop + supabase deploy) fica como TODO até
+Fred liberar a primeira execução de auto-fix em produção.
+
+Modos:
+- Default: detect+act (chamado a cada 15 min)
+- IS_DIGEST=true: monta resumo das últimas 24h e manda Telegram
+
+Saída: prints no stdout (visíveis nos logs do GitHub Action).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import requests
+from supabase import Client, create_client
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+SUPABASE_URL = os.environ["SUPABASE_URL"]
+SUPABASE_KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+TG_BOT = os.environ.get("TELEGRAM_BOT_TOKEN")
+TG_CHAT = os.environ.get("TELEGRAM_CHAT_MONITOR")
+IS_DIGEST = os.environ.get("IS_DIGEST", "false").lower() == "true"
+
+# Whitelist conservadora — só esses tipos podem ser auto-fixados na v1.
+# Pra expandir, adicione o `kind` aqui E implemente o handler em apply_auto_fix().
+AUTO_FIX_WHITELIST_KINDS = {"generic_fallback"}
+
+# Bobby v1 ainda NÃO aplica patches automaticamente sem revisão humana.
+# Quando Fred liberar, mude pra True e implemente apply_auto_fix().
+AUTO_FIX_ENABLED = False
+
+
+def send_telegram(text: str) -> None:
+    if not TG_BOT or not TG_CHAT:
+        print(f"[telegram-skipped] {text[:120]}")
+        return
+    requests.post(
+        f"https://api.telegram.org/bot{TG_BOT}/sendMessage",
+        json={"chat_id": TG_CHAT, "text": text, "parse_mode": "Markdown"},
+        timeout=10,
+    )
+
+
+def fetch_open_incidents(sb: Client) -> list[dict[str, Any]]:
+    res = (
+        sb.table("tais_incidents")
+        .select("*")
+        .eq("status", "open")
+        .order("severity", desc=True)
+        .order("last_seen_at", desc=True)
+        .limit(20)
+        .execute()
+    )
+    return res.data or []
+
+
+def acknowledge(sb: Client, incident_id: str, note: str) -> None:
+    sb.table("tais_incidents").update(
+        {"status": "acknowledged", "notes": note}
+    ).eq("id", incident_id).execute()
+
+
+def apply_auto_fix(sb: Client, inc: dict[str, Any]) -> dict[str, Any]:
+    """Stub. Quando AUTO_FIX_ENABLED=True, implementa loop tool_use Anthropic:
+    1. Lê audit_log da conversa pra identificar user_text que disparou
+    2. Anthropic Claude (claude-sonnet-4-6) com tools: read_file, str_replace,
+       deno_check, supabase_deploy
+    3. Aplica patch em ~/tais-edge/supabase/functions/_shared/handlers.ts
+    4. Valida, deploya, commita
+    5. Retorna dict com commit, version, deploy_status
+    """
+    raise NotImplementedError("auto-fix ainda não habilitado na v1")
+
+
+def handle_detect_act(sb: Client) -> None:
+    incidents = fetch_open_incidents(sb)
+    print(f"[detect_act] {len(incidents)} incidents open")
+    if not incidents:
+        return
+
+    by_kind: dict[str, list[dict[str, Any]]] = {}
+    for inc in incidents:
+        by_kind.setdefault(inc["kind"], []).append(inc)
+
+    for kind, items in by_kind.items():
+        print(f"  - {kind}: {len(items)}")
+
+    for inc in incidents:
+        kind = inc["kind"]
+        if kind in AUTO_FIX_WHITELIST_KINDS and AUTO_FIX_ENABLED:
+            try:
+                result = apply_auto_fix(sb, inc)
+                sb.table("tais_incidents").update(
+                    {
+                        "status": "auto_fixed",
+                        "auto_fix_attempted": True,
+                        "auto_fix_result": result,
+                        "resolved_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                ).eq("id", inc["id"]).execute()
+                send_telegram(
+                    f"✅ *Bobby auto-fix* — `{kind}`\n"
+                    f"Commit: `{result.get('commit', '?')}`\n"
+                    f"Version: `{result.get('version', '?')}`"
+                )
+            except Exception as exc:  # pragma: no cover
+                acknowledge(sb, inc["id"], f"auto_fix_failed: {exc}")
+                send_telegram(
+                    f"⚠️ *Bobby auto-fix FALHOU* — `{kind}`\n"
+                    f"Incident: `{inc['id']}`\n"
+                    f"Erro: `{exc}`"
+                )
+        else:
+            note_prefix = (
+                "whitelisted_but_auto_fix_disabled" if kind in AUTO_FIX_WHITELIST_KINDS
+                else "not_whitelisted"
+            )
+            ev = json.dumps(inc.get("evidence", {}))[:200]
+            note = f"{note_prefix}: needs_human_review | evidence={ev}"
+            acknowledge(sb, inc["id"], note)
+            emoji = "🚨" if inc["severity"] == "error" else "⚠️"
+            send_telegram(
+                f"{emoji} *Bobby alert* — `{kind}` ({inc['severity']})\n"
+                f"Incident: `{inc['id']}`\n"
+                f"Conv: `{inc.get('conversation_id', 'n/a')}`\n"
+                f"Status: needs_human_review\n"
+                f"Evidence: `{ev}`"
+            )
+
+
+def handle_digest(sb: Client) -> None:
+    since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    res = (
+        sb.table("tais_incidents")
+        .select("kind, status, severity")
+        .gte("first_seen_at", since)
+        .execute()
+    )
+    rows = res.data or []
+    if not rows:
+        send_telegram("📊 *Bobby digest 24h*\nNenhum incident detectado. 🎉")
+        return
+
+    by_kind_status: dict[tuple[str, str], int] = {}
+    for r in rows:
+        key = (r["kind"], r["status"])
+        by_kind_status[key] = by_kind_status.get(key, 0) + 1
+
+    lines = ["📊 *Bobby digest 24h*", f"Total: {len(rows)} incidents", ""]
+    for (kind, status), count in sorted(by_kind_status.items()):
+        lines.append(f"• `{kind}` — {status}: {count}")
+    send_telegram("\n".join(lines))
+
+
+def main() -> int:
+    sb: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
+    if IS_DIGEST:
+        handle_digest(sb)
+    else:
+        handle_detect_act(sb)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds **Bobby** as a DevOps agent that continuously monitors the TAIS WhatsApp assistant (TERSERV project) for regressions and known failure modes, alerts via Telegram, and auto-fixes a conservative whitelist of issues.

This PR is the *agent side* of the system. The backing infra (Supabase migrations + edge function `sentinel-notify`) is already deployed in production (Supabase project `rixnvftlzhfkavbfcipn`), independent of this PR.

### What's in this PR

- `agents/bobby/SKILL.md` — full agent specification: whitelist, procedure per incident, secrets, evolution plan.
- `agents/bobby/sentinel.py` — Python runner.
  - **Conservative v1**: `AUTO_FIX_ENABLED=False`. Bobby only **alerts** for now. `apply_auto_fix()` is a stub until Fred enables it.
  - Whitelist contains exactly **one** kind: `generic_fallback`.
  - `IS_DIGEST=true` mode emits a 24h summary to Telegram.
- `.github/workflows/bobby-sentinel.yml` — Action schedules `*/15 * * * *` for detect-act, plus `0 22 * * *` for the daily digest. `workflow_dispatch` for manual runs.

### Production infra (already deployed, for context)

| Component | Status |
|---|---|
| Migration `20260522140000_tais_sentinel.sql` (table `tais_incidents` + 6 `detect_*` functions + cron `tais-sentinel-detect`) | ACTIVE |
| Migration `20260522141000_tais_sentinel_notify_cron.sql` (cron `tais-sentinel-notify`) | ACTIVE |
| Edge function `sentinel-notify` | v1 ACTIVE, smoke test returns `{"sent": 0}` |

### Secrets needed (GitHub repo Settings → Secrets)

Before enabling the workflow:

- `ANTHROPIC_API_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`
- `SUPABASE_ACCESS_TOKEN`
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_MONITOR`
- `GH_PAT` (only needed once `terserv/tais-edge` remote exists)

### Test plan

- [ ] Add secrets to repo
- [ ] Manually trigger workflow via `gh workflow run "Bobby TAIS Sentinel"` — confirm no errors, no incidents found
- [ ] Wait for next scheduled run (`*/15 * * * *`) — confirm action runs cleanly
- [ ] Trigger digest manually via env override — confirm Telegram message arrives
- [ ] When ready: flip `AUTO_FIX_ENABLED=True` in `sentinel.py` only after `apply_auto_fix()` is implemented and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)